### PR TITLE
Replace datetime.utcnow

### DIFF
--- a/devialet/devialet_api.py
+++ b/devialet/devialet_api.py
@@ -68,7 +68,7 @@ class DevialetApi:
             position = await self.get_request(UrlSuffix.GET_CURRENT_POSITION)
             try:
                 self._current_position = position["position"]
-                self._position_updated_at = datetime.datetime.utcnow()
+                self._position_updated_at = datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
             except (KeyError, TypeError):
                 self._current_position = None
                 self._position_updated_at = None


### PR DESCRIPTION
Starting with Python 3.12 `datetime.utcnow` is deprecated.

https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow

Fixes
```
  /home/runner/work/core/core/venv/lib/python3.12/site-packages/devialet/devialet_api.py:71:
      DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.
      Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self._position_updated_at = datetime.datetime.utcnow()
```